### PR TITLE
Fix multiallelic freq merge, window_step validation, and empty result crash

### DIFF
--- a/src/pie/cli.py
+++ b/src/pie/cli.py
@@ -31,7 +31,7 @@ def main():
 @click.option("--min-qual", default=20.0, show_default=True, help="Minimum variant quality")
 @click.option("--pass-only", is_flag=True, help="Only use PASS-filtered variants")
 @click.option("--window-size", default=1000, show_default=True, help="Sliding window size (bp)")
-@click.option("--window-step", default=100, show_default=True, help="Sliding window step (bp)")
+@click.option("--window-step", default=100, show_default=True, type=click.IntRange(min=1), help="Sliding window step (bp)")
 @click.option("--threads", default=1, show_default=True, help="Number of threads")
 def run(vcf, gff, fasta, outdir, min_freq, min_depth, min_qual, pass_only,
         window_size, window_step, threads):

--- a/src/pie/io.py
+++ b/src/pie/io.py
@@ -35,8 +35,9 @@ def write_gene_results(results: list[GeneResult], path: str) -> None:
             "n_variants": r.n_variants,
         })
     df = pd.DataFrame(rows)
-    # Convert "NA" strings to actual NaN for proper TSV handling
-    df["piN_piS"] = pd.to_numeric(df["piN_piS"], errors="coerce")
+    if not df.empty:
+        # Convert "NA" strings to actual NaN for proper TSV handling
+        df["piN_piS"] = pd.to_numeric(df["piN_piS"], errors="coerce")
     df.to_csv(path, sep="\t", index=False)
 
 

--- a/src/pie/vcf.py
+++ b/src/pie/vcf.py
@@ -111,7 +111,7 @@ class VariantReader:
             else:
                 # Merge: recompute frequencies using allele depths
                 ref_count = group[0][5]
-                if ref_count > 0:
+                if ref_count > 0 or any(r[6] > 0 for r in group):
                     total_alt = sum(r[6] for r in group)
                     total_depth = ref_count + total_alt
                     for r in group:
@@ -122,7 +122,7 @@ class VariantReader:
                                 pos=r[0], ref=r[1], alt=r[2],
                                 freq=new_freq, depth=total_depth))
                 else:
-                    # No raw allele counts — keep original frequencies
+                    # No raw allele depths available — keep original frequencies
                     for r in group:
                         variants.append(Variant(
                             pos=r[0], ref=r[1], alt=r[2],


### PR DESCRIPTION
## Summary
- **vcf.py**: Fix allele frequency recomputation for multiallelic sites where REF count is 0 but AD data is available. Previously `ref_count > 0` was used as a proxy for "has AD data", which is wrong when REF has 0 reads (e.g. decomposed `AD=0,30` + `AD=0,70` produced 1.0/1.0 → renormalized to 0.5/0.5 instead of correct 0.3/0.7)
- **cli.py**: Validate `--window-step >= 1` via `click.IntRange` to prevent infinite loop in sliding window
- **io.py**: Guard `write_gene_results` against empty result sets (`pd.DataFrame([])` has no columns → `KeyError` on `df["piN_piS"]`), matching existing guard in `write_window_results`

## Test plan
- [x] All 101 existing tests pass
- [x] Verify multiallelic site with REF=0 produces correct frequencies
- [x] Verify `--window-step 0` is rejected by CLI
- [x] Verify empty gene results writes valid empty TSV