### PR TITLE
feat: add --variant-table per-variant annotation output

### DIFF
--- a/src/pie/cli.py
+++ b/src/pie/cli.py
@@ -90,6 +90,7 @@ def _shared_run_options(f):
         ),
         (("-t", "--threads"), {"default": 1, "show_default": True, "help": "Number of parallel threads."}),
         (("--quiet",), {"is_flag": True, "help": "Suppress progress messages (show only warnings and summary)."}),
+        (("--variant-table",), {"is_flag": True, "help": "Write per-variant annotation table (variant_results.tsv)."}),
     ])
 
 
@@ -100,7 +101,8 @@ def _shared_run_options(f):
 def _run_analysis(*, vcf, gff, fasta, outdir, mode, min_freq, min_depth,
                   min_qual, pass_only, keep_multiallelic, include_stop_codons,
                   window_size, window_step, threads, quiet, sample=None,
-                  samples=None, min_call_rate=None, min_an=None):
+                  samples=None, min_call_rate=None, min_an=None,
+                  variant_table=False):
     """Core analysis logic shared by pool and ind subcommands."""
     from pie.vcf import ensure_indexed, get_sample_names
     from pie.parallel import run_parallel
@@ -185,6 +187,7 @@ def _run_analysis(*, vcf, gff, fasta, outdir, mode, min_freq, min_depth,
             exclude_stops=not include_stop_codons, threads=threads,
             sample=sample, mode=mode, samples=selected_samples,
             min_call_rate=min_call_rate, min_an=min_an,
+            emit_variants=variant_table,
         )
     except (NoGenesFoundError, ValueError) as exc:
         click.echo(f"Error: {exc}", err=True)
@@ -207,6 +210,16 @@ def _run_analysis(*, vcf, gff, fasta, outdir, mode, min_freq, min_depth,
     write_summary(results, summary_path)
     log.info("Summary: %s", summary_path)
 
+    if variant_table:
+        from pie.io import write_variant_results
+        all_variant_records = []
+        for r in results:
+            if r.variant_records:
+                all_variant_records.extend(r.variant_records)
+        var_path = os.path.join(outdir, f"{prefix}variant_results.tsv")
+        write_variant_results(all_variant_records, var_path)
+        log.info("Variant table: %s (%d variants)", var_path, len(all_variant_records))
+
     click.echo(f"Done. Results written to {outdir}/")
 
 
@@ -222,7 +235,7 @@ def _run_analysis(*, vcf, gff, fasta, outdir, mode, min_freq, min_depth,
               help="Sample name to analyse (for multi-sample VCFs).")
 def pool(vcf, gff, fasta, outdir, min_freq, min_qual, pass_only,
          keep_multiallelic, include_stop_codons, window_size, window_step,
-         threads, quiet, min_depth, sample):
+         threads, quiet, variant_table, min_depth, sample):
     """Run pool-seq piN/piS analysis (allele-frequency based).
 
     \b
@@ -245,6 +258,7 @@ def pool(vcf, gff, fasta, outdir, min_freq, min_qual, pass_only,
         pass_only=pass_only, keep_multiallelic=keep_multiallelic,
         include_stop_codons=include_stop_codons, window_size=window_size,
         window_step=window_step, threads=threads, quiet=quiet, sample=sample,
+        variant_table=variant_table,
     )
 
 
@@ -264,7 +278,7 @@ def pool(vcf, gff, fasta, outdir, min_freq, min_qual, pass_only,
               help="Minimum allele number (AN).")
 def ind(vcf, gff, fasta, outdir, min_freq, min_qual, pass_only,
         keep_multiallelic, include_stop_codons, window_size, window_step,
-        threads, quiet, samples, samples_file, min_call_rate, min_an):
+        threads, quiet, variant_table, samples, samples_file, min_call_rate, min_an):
     """Run individual-sequencing piN/piS analysis (genotype based).
 
     \b
@@ -306,6 +320,7 @@ def ind(vcf, gff, fasta, outdir, min_freq, min_qual, pass_only,
         include_stop_codons=include_stop_codons, window_size=window_size,
         window_step=window_step, threads=threads, quiet=quiet,
         samples=resolved_samples, min_call_rate=min_call_rate, min_an=min_an,
+        variant_table=variant_table,
     )
 
 

--- a/src/pie/diversity.py
+++ b/src/pie/diversity.py
@@ -92,7 +92,6 @@ class VariantRecord:
     ro: int
     dp: int
     af: float           # ao / (ao + ro)
-    # Nice-to-have fields
     strand: str = "+"
     cds_position: int = 0   # 1-based nucleotide position within CDS
     n_sites: float = 0.0    # fractional N site count at this codon position
@@ -146,6 +145,18 @@ class GeneResult:
         return self.piN / self.piS if self.piS > 0 else None
 
 
+def _build_pos_map(
+    positions: list[tuple[str, int, int, int]],
+) -> dict[int, tuple[int, int]]:
+    """Map genomic position -> (codon_index, position_within_codon)."""
+    pos_map: dict[int, tuple[int, int]] = {}
+    for i, (_chrom, p1, p2, p3) in enumerate(positions):
+        pos_map[p1] = (i, 0)
+        pos_map[p2] = (i, 1)
+        pos_map[p3] = (i, 2)
+    return pos_map
+
+
 # ---------------------------------------------------------------------------
 # 1. Build allele frequency array
 # ---------------------------------------------------------------------------
@@ -182,12 +193,7 @@ def build_allele_freq_array(
     if not variants:
         return freq
 
-    # Build lookup: genomic_pos -> (codon_idx, pos_within_codon)
-    pos_map: dict[int, tuple[int, int]] = {}
-    for i, (chrom, p1, p2, p3) in enumerate(positions):
-        pos_map[p1] = (i, 0)
-        pos_map[p2] = (i, 1)
-        pos_map[p3] = (i, 2)
+    pos_map = _build_pos_map(positions)
 
     # Group variants by position for proper multi-allelic handling
     pos_variants: dict[int, list[Variant]] = {}
@@ -243,12 +249,7 @@ def annotate_variants(
     else:
         n_sites_tbl, s_sites_tbl = N_SITES, S_SITES
 
-    # Build pos -> (codon_idx, pos_within_codon) lookup
-    pos_map: dict[int, tuple[int, int]] = {}
-    for i, (chrom, p1, p2, p3) in enumerate(positions):
-        pos_map[p1] = (i, 0)
-        pos_map[p2] = (i, 1)
-        pos_map[p3] = (i, 2)
+    pos_map = _build_pos_map(positions)
 
     records: list[VariantRecord] = []
     for var in variants:

--- a/src/pie/diversity.py
+++ b/src/pie/diversity.py
@@ -11,6 +11,7 @@ from itertools import product
 import numpy as np
 
 from pie.codon import (
+    AMINO_ACID,
     CODON_TO_INDEX,
     IS_STOP,
     N_DIFFS,
@@ -67,6 +68,37 @@ class CodonResult:
     S_diffs: float
 
 
+@dataclass(slots=True)
+class VariantRecord:
+    """Per-variant annotation record for the variant table output.
+
+    Note: ao/ro come from FORMAT/AD in pool mode or GT allele counts in
+    individual mode. When AD is absent (INFO/AF fallback), ao=0, ro=0,
+    and af=0.0. In individual mode, dp is AN (allele number), not read depth.
+    """
+
+    chrom: str
+    pos: int            # 1-based genomic position
+    ref: str
+    alt: str
+    gene_id: str
+    codon_pos: int      # 1-based position within codon (1, 2, or 3)
+    ref_codon: str
+    alt_codon: str
+    ref_aa: str
+    alt_aa: str
+    variant_class: str  # synonymous, nonsynonymous, stop_gained, stop_lost
+    ao: int
+    ro: int
+    dp: int
+    af: float           # ao / (ao + ro)
+    # Nice-to-have fields
+    strand: str = "+"
+    cds_position: int = 0   # 1-based nucleotide position within CDS
+    n_sites: float = 0.0    # fractional N site count at this codon position
+    s_sites: float = 0.0    # fractional S site count at this codon position
+
+
 @dataclass
 class GeneResult:
     """Per-gene diversity result."""
@@ -93,6 +125,7 @@ class GeneResult:
     n_ambiguous_codons: int = 0
     n_internal_stop_codons: int = 0
     filter_stats: FilterStats = field(default_factory=FilterStats)
+    variant_records: list[VariantRecord] | None = None
 
     @property
     def mean_call_rate(self) -> float | None:
@@ -188,6 +221,88 @@ def build_allele_freq_array(
     freq /= sums
 
     return freq
+
+
+# ---------------------------------------------------------------------------
+# 1b. Annotate individual variants with codon context
+# ---------------------------------------------------------------------------
+def annotate_variants(
+    codons: list[str],
+    positions: list[tuple[str, int, int, int]],
+    variants: list[Variant],
+    gene_id: str,
+    strand: str = "+",
+    exclude_stops: bool = False,
+) -> list[VariantRecord]:
+    """Annotate each variant with codon context and amino acid change."""
+    if not variants or not codons:
+        return []
+
+    if exclude_stops:
+        n_sites_tbl, s_sites_tbl = N_SITES_EXCL_STOP, S_SITES_EXCL_STOP
+    else:
+        n_sites_tbl, s_sites_tbl = N_SITES, S_SITES
+
+    # Build pos -> (codon_idx, pos_within_codon) lookup
+    pos_map: dict[int, tuple[int, int]] = {}
+    for i, (chrom, p1, p2, p3) in enumerate(positions):
+        pos_map[p1] = (i, 0)
+        pos_map[p2] = (i, 1)
+        pos_map[p3] = (i, 2)
+
+    records: list[VariantRecord] = []
+    for var in variants:
+        if var.pos not in pos_map:
+            continue
+
+        codon_idx, pos_in_codon = pos_map[var.pos]
+        ref_codon = codons[codon_idx]
+
+        # Complement alt allele for minus strand
+        alt_base = _COMPLEMENT_BASE[var.alt] if strand == "-" else var.alt
+        alt_codon = ref_codon[:pos_in_codon] + alt_base + ref_codon[pos_in_codon + 1:]
+
+        ref_aa = AMINO_ACID[CODON_TO_INDEX[ref_codon]]
+        alt_aa = AMINO_ACID[CODON_TO_INDEX[alt_codon]]
+
+        if ref_aa == alt_aa:
+            vclass = "synonymous"
+        elif alt_aa == "*":
+            vclass = "stop_gained"
+        elif ref_aa == "*":
+            vclass = "stop_lost"
+        else:
+            vclass = "nonsynonymous"
+
+        ao_ro_sum = var.ao + var.ro
+        af = var.ao / ao_ro_sum if ao_ro_sum > 0 else 0.0
+
+        codon_table_idx = CODON_TO_INDEX[ref_codon]
+        cds_pos = codon_idx * 3 + pos_in_codon + 1  # 1-based
+
+        records.append(VariantRecord(
+            chrom=positions[codon_idx][0],
+            pos=var.pos + 1,  # convert to 1-based
+            ref=var.ref,
+            alt=var.alt,
+            gene_id=gene_id,
+            codon_pos=pos_in_codon + 1,  # 1-based
+            ref_codon=ref_codon,
+            alt_codon=alt_codon,
+            ref_aa=ref_aa,
+            alt_aa=alt_aa,
+            variant_class=vclass,
+            ao=var.ao,
+            ro=var.ro,
+            dp=var.depth,
+            af=af,
+            strand=strand,
+            cds_position=cds_pos,
+            n_sites=float(n_sites_tbl[codon_table_idx, pos_in_codon]),
+            s_sites=float(s_sites_tbl[codon_table_idx, pos_in_codon]),
+        ))
+
+    return records
 
 
 # ---------------------------------------------------------------------------
@@ -297,6 +412,7 @@ def compute_gene_diversity(
     ref: ReferenceGenome,
     vcf: VariantReaderLike,
     exclude_stops: bool = False,
+    emit_variants: bool = False,
 ) -> GeneResult:
     """Compute per-gene piN/piS diversity.
 
@@ -473,6 +589,15 @@ def compute_gene_diversity(
     # Collect per-variant call rates (individual mode only)
     cr_list = [v.call_rate for v in all_variants if v.call_rate is not None]
 
+    # Annotate individual variants when requested
+    variant_records = None
+    if emit_variants and all_variants:
+        variant_records = annotate_variants(
+            codons=codons, positions=positions, variants=all_variants,
+            gene_id=gene.gene_id, strand=gene.strand,
+            exclude_stops=exclude_stops,
+        )
+
     return GeneResult(
         gene_id=gene.gene_id,
         transcript_id=gene.transcript_id,
@@ -494,4 +619,5 @@ def compute_gene_diversity(
         n_ambiguous_codons=n_ambiguous,
         n_internal_stop_codons=n_internal_stops,
         filter_stats=gene_filter_stats,
+        variant_records=variant_records,
     )

--- a/src/pie/diversity.py
+++ b/src/pie/diversity.py
@@ -91,7 +91,7 @@ class VariantRecord:
     ao: int
     ro: int
     dp: int
-    af: float           # ao / (ao + ro)
+    af: float           # ao / dp (site-wide depth, not ao+ro)
     strand: str = "+"
     cds_position: int = 0   # 1-based nucleotide position within CDS
     n_sites: float = 0.0    # fractional N site count at this codon position
@@ -275,8 +275,7 @@ def annotate_variants(
         else:
             vclass = "nonsynonymous"
 
-        ao_ro_sum = var.ao + var.ro
-        af = var.ao / ao_ro_sum if ao_ro_sum > 0 else 0.0
+        af = var.ao / var.depth if var.depth > 0 else 0.0
 
         codon_table_idx = CODON_TO_INDEX[ref_codon]
         cds_pos = codon_idx * 3 + pos_in_codon + 1  # 1-based

--- a/src/pie/io.py
+++ b/src/pie/io.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from bisect import bisect_left
 
 import numpy as np
@@ -9,32 +10,16 @@ import pandas as pd
 
 from pie.diversity import GeneResult, VariantRecord
 
+_VARIANT_COLUMNS = [f.name for f in dataclasses.fields(VariantRecord)]
+
 
 def write_variant_results(records: list[VariantRecord], path: str) -> None:
     """Write per-variant TSV with codon annotation and allele counts."""
-    columns = [
-        "chrom", "pos", "ref", "alt", "gene_id", "codon_pos",
-        "ref_codon", "alt_codon", "ref_aa", "alt_aa", "variant_class",
-        "ao", "ro", "dp", "af", "strand", "cds_position",
-        "n_sites", "s_sites",
-    ]
     if not records:
-        pd.DataFrame(columns=columns).to_csv(path, sep="\t", index=False)
+        pd.DataFrame(columns=_VARIANT_COLUMNS).to_csv(path, sep="\t", index=False)
         return
-    rows = [
-        {
-            "chrom": r.chrom, "pos": r.pos, "ref": r.ref, "alt": r.alt,
-            "gene_id": r.gene_id, "codon_pos": r.codon_pos,
-            "ref_codon": r.ref_codon, "alt_codon": r.alt_codon,
-            "ref_aa": r.ref_aa, "alt_aa": r.alt_aa,
-            "variant_class": r.variant_class,
-            "ao": r.ao, "ro": r.ro, "dp": r.dp, "af": r.af,
-            "strand": r.strand, "cds_position": r.cds_position,
-            "n_sites": r.n_sites, "s_sites": r.s_sites,
-        }
-        for r in records
-    ]
-    pd.DataFrame(rows, columns=columns).to_csv(path, sep="\t", index=False)
+    rows = [[getattr(r, c) for c in _VARIANT_COLUMNS] for r in records]
+    pd.DataFrame(rows, columns=_VARIANT_COLUMNS).to_csv(path, sep="\t", index=False)
 
 
 def write_gene_results(results: list[GeneResult], path: str) -> None:

--- a/src/pie/io.py
+++ b/src/pie/io.py
@@ -7,7 +7,34 @@ from bisect import bisect_left
 import numpy as np
 import pandas as pd
 
-from pie.diversity import GeneResult
+from pie.diversity import GeneResult, VariantRecord
+
+
+def write_variant_results(records: list[VariantRecord], path: str) -> None:
+    """Write per-variant TSV with codon annotation and allele counts."""
+    columns = [
+        "chrom", "pos", "ref", "alt", "gene_id", "codon_pos",
+        "ref_codon", "alt_codon", "ref_aa", "alt_aa", "variant_class",
+        "ao", "ro", "dp", "af", "strand", "cds_position",
+        "n_sites", "s_sites",
+    ]
+    if not records:
+        pd.DataFrame(columns=columns).to_csv(path, sep="\t", index=False)
+        return
+    rows = [
+        {
+            "chrom": r.chrom, "pos": r.pos, "ref": r.ref, "alt": r.alt,
+            "gene_id": r.gene_id, "codon_pos": r.codon_pos,
+            "ref_codon": r.ref_codon, "alt_codon": r.alt_codon,
+            "ref_aa": r.ref_aa, "alt_aa": r.alt_aa,
+            "variant_class": r.variant_class,
+            "ao": r.ao, "ro": r.ro, "dp": r.dp, "af": r.af,
+            "strand": r.strand, "cds_position": r.cds_position,
+            "n_sites": r.n_sites, "s_sites": r.s_sites,
+        }
+        for r in records
+    ]
+    pd.DataFrame(rows, columns=columns).to_csv(path, sep="\t", index=False)
 
 
 def write_gene_results(results: list[GeneResult], path: str) -> None:

--- a/src/pie/parallel.py
+++ b/src/pie/parallel.py
@@ -15,15 +15,16 @@ log = logging.getLogger(__name__)
 
 def _worker_init(fasta_path, vcf_path, min_freq, min_depth, min_qual,
                  pass_only, keep_multiallelic, exclude_stops, sample,
-                 mode, samples, min_call_rate, min_an):
+                 mode, samples, min_call_rate, min_an, emit_variants):
     """Initialize per-worker file handles (stored in globals)."""
     # Suppress noisy cyvcf2/htslib "no intervals found" warnings that fire
     # for every empty-region tabix query (tens per run, no diagnostic value).
     warnings.filterwarnings("ignore", message="no intervals found",
                             category=UserWarning)
-    global _ref, _vcf, _exclude_stops, _n_samples
+    global _ref, _vcf, _exclude_stops, _n_samples, _emit_variants
     _ref = ReferenceGenome(fasta_path)
     _exclude_stops = exclude_stops
+    _emit_variants = emit_variants
 
     if mode == "individual":
         _vcf = IndividualVariantReader(
@@ -54,7 +55,8 @@ def _worker_cleanup():
 def _process_gene(gene: GeneModel) -> GeneResult:
     """Process a single gene using worker-local handles."""
     try:
-        result = compute_gene_diversity(gene, _ref, _vcf, exclude_stops=_exclude_stops)
+        result = compute_gene_diversity(gene, _ref, _vcf, exclude_stops=_exclude_stops,
+                                         emit_variants=_emit_variants)
         result.n_samples = _n_samples
         return result
     except Exception as exc:
@@ -80,6 +82,7 @@ def run_parallel(
     samples: list[str] | None = None,
     min_call_rate: float = 0.8,
     min_an: int = 2,
+    emit_variants: bool = False,
 ) -> list[GeneResult]:
     """Run piN/piS analysis across all genes.
 
@@ -125,7 +128,7 @@ def run_parallel(
 
     init_args = (fasta_path, vcf_path, min_freq, min_depth, min_qual,
                  pass_only, keep_multiallelic, exclude_stops, sample,
-                 mode, samples, min_call_rate, min_an)
+                 mode, samples, min_call_rate, min_an, emit_variants)
 
     if threads <= 1:
         # Single-threaded: no multiprocessing overhead

--- a/src/pie/vcf.py
+++ b/src/pie/vcf.py
@@ -55,6 +55,8 @@ class Variant:
     alt: str      # alternate allele
     freq: float   # alt allele frequency (0-1)
     depth: int    # total depth (read depth in pool mode, AN in individual mode)
+    ao: int = 0   # alt allele observation count
+    ro: int = 0   # ref allele observation count
     call_rate: float | None = None  # fraction of called samples (individual mode only)
 
 
@@ -217,7 +219,7 @@ class VariantReader(_BaseVariantReader):
             group = by_pos[pos]
             is_multiallelic = pos in multiallelic_pos
             if not is_multiallelic:
-                p, ref, alt, freq, depth, _, _ = group[0]
+                p, ref, alt, freq, depth, ref_c, alt_c = group[0]
                 if depth < self._min_depth:
                     stats.n_filtered_depth += 1
                     continue
@@ -225,7 +227,8 @@ class VariantReader(_BaseVariantReader):
                     stats.n_filtered_freq += 1
                     continue
                 variants.append(Variant(
-                    pos=p, ref=ref, alt=alt, freq=freq, depth=depth))
+                    pos=p, ref=ref, alt=alt, freq=freq, depth=depth,
+                    ao=alt_c, ro=ref_c))
             elif not self._keep_multiallelic:
                 # Skip multiallelic sites by default
                 stats.n_filtered_multiallelic += 1
@@ -247,7 +250,8 @@ class VariantReader(_BaseVariantReader):
                         if new_freq >= self._min_freq:
                             variants.append(Variant(
                                 pos=r[0], ref=r[1], alt=r[2],
-                                freq=new_freq, depth=total_depth))
+                                freq=new_freq, depth=total_depth,
+                                ao=r[6], ro=ref_count))
                         else:
                             stats.n_filtered_freq += 1
                 else:
@@ -261,7 +265,8 @@ class VariantReader(_BaseVariantReader):
                             continue
                         variants.append(Variant(
                             pos=r[0], ref=r[1], alt=r[2],
-                            freq=r[3], depth=r[4]))
+                            freq=r[3], depth=r[4],
+                            ao=r[6], ro=r[5]))
 
         return FetchResult(variants, stats)
 
@@ -449,21 +454,23 @@ class IndividualVariantReader(_BaseVariantReader):
             group = by_pos[pos]
             is_multiallelic = pos in multiallelic_pos
             if not is_multiallelic:
-                p, ref, alt, freq, depth, _, _, cr = group[0]
+                p, ref, alt, freq, depth, ref_c, alt_c, cr = group[0]
                 if freq < self._min_freq:
                     stats.n_filtered_freq += 1
                     continue
                 variants.append(Variant(pos=p, ref=ref, alt=alt,
-                                        freq=freq, depth=depth, call_rate=cr))
+                                        freq=freq, depth=depth,
+                                        ao=alt_c, ro=ref_c, call_rate=cr))
             elif not self._keep_multiallelic:
                 stats.n_filtered_multiallelic += 1
                 continue
             else:
                 for r in group:
-                    p, ref, alt, freq, depth, _, _, cr = r
+                    p, ref, alt, freq, depth, ref_c, alt_c, cr = r
                     if freq >= self._min_freq:
                         variants.append(Variant(pos=p, ref=ref, alt=alt,
                                                 freq=freq, depth=depth,
+                                                ao=alt_c, ro=ref_c,
                                                 call_rate=cr))
                     else:
                         stats.n_filtered_freq += 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -370,7 +370,7 @@ class TestVariantTableFlag:
         assert "variant_class" in df.columns
         assert "ao" in df.columns
         for _, row in df.iterrows():
-            expected_af = row["ao"] / (row["ao"] + row["ro"])
+            expected_af = row["ao"] / row["dp"]
             assert abs(row["af"] - expected_af) < 1e-6
 
     def test_no_variant_table_by_default(self, runner, ref_fasta, gff3_file, vcf_file, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -355,7 +355,7 @@ class TestIndividualMode:
 
 class TestVariantTableFlag:
     def test_pool_variant_table_produced(self, runner, ref_fasta, gff3_file, vcf_file, tmp_path):
-        from pie.cli import main
+        import pandas as pd
         outdir = str(tmp_path / "out")
         result = runner.invoke(main, [
             "pool", "-v", vcf_file, "-g", gff3_file, "-f", ref_fasta,
@@ -363,7 +363,6 @@ class TestVariantTableFlag:
             "--variant-table",
         ])
         assert result.exit_code == 0, result.output
-        import pandas as pd
         vpath = os.path.join(outdir, "variant_results.tsv")
         assert os.path.exists(vpath)
         df = pd.read_csv(vpath, sep="\t")
@@ -375,7 +374,6 @@ class TestVariantTableFlag:
             assert abs(row["af"] - expected_af) < 1e-6
 
     def test_no_variant_table_by_default(self, runner, ref_fasta, gff3_file, vcf_file, tmp_path):
-        from pie.cli import main
         outdir = str(tmp_path / "out")
         result = runner.invoke(main, [
             "pool", "-v", vcf_file, "-g", gff3_file, "-f", ref_fasta,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import os
+
 from pie.cli import main
 
 
@@ -349,3 +351,35 @@ class TestIndividualMode:
             "--min-freq", "0", "--min-qual", "0", "--min-call-rate", "0",
         ])
         assert result.exit_code == 0, result.output
+
+
+class TestVariantTableFlag:
+    def test_pool_variant_table_produced(self, runner, ref_fasta, gff3_file, vcf_file, tmp_path):
+        from pie.cli import main
+        outdir = str(tmp_path / "out")
+        result = runner.invoke(main, [
+            "pool", "-v", vcf_file, "-g", gff3_file, "-f", ref_fasta,
+            "-o", outdir, "-d", "0", "-q", "0", "--min-freq", "0",
+            "--variant-table",
+        ])
+        assert result.exit_code == 0, result.output
+        import pandas as pd
+        vpath = os.path.join(outdir, "variant_results.tsv")
+        assert os.path.exists(vpath)
+        df = pd.read_csv(vpath, sep="\t")
+        assert len(df) > 0
+        assert "variant_class" in df.columns
+        assert "ao" in df.columns
+        for _, row in df.iterrows():
+            expected_af = row["ao"] / (row["ao"] + row["ro"])
+            assert abs(row["af"] - expected_af) < 1e-6
+
+    def test_no_variant_table_by_default(self, runner, ref_fasta, gff3_file, vcf_file, tmp_path):
+        from pie.cli import main
+        outdir = str(tmp_path / "out")
+        result = runner.invoke(main, [
+            "pool", "-v", vcf_file, "-g", gff3_file, "-f", ref_fasta,
+            "-o", outdir, "-d", "0", "-q", "0", "--min-freq", "0",
+        ])
+        assert result.exit_code == 0
+        assert not os.path.exists(os.path.join(outdir, "variant_results.tsv"))

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -1,14 +1,17 @@
 """Tests for the core piN/piS diversity engine."""
 
+import pytest
 import numpy as np
 from pie.codon import codon_to_index, N_SITES, S_SITES, CODON_TO_INDEX
 from pie.diversity import (
     _monomorphic_codon_index,
+    annotate_variants,
     build_allele_freq_array,
     compute_codon_diversity,
     compute_gene_diversity,
     CodonResult,
     GeneResult,
+    VariantRecord,
 )
 from pie.vcf import FetchResult, FilterStats, Variant
 
@@ -433,3 +436,154 @@ class TestFixedAltMonomorphicSiteCounts:
         # Confirm it's NOT the reference AAA site counts
         ref_n = float(N_SITES[CODON_TO_INDEX["AAA"]].sum())
         assert abs(cr0.N_sites - ref_n) > 0.1  # delta is 0.6667
+
+
+class TestVariantRecord:
+    """Test that VariantRecord can be constructed."""
+
+    def test_construction(self):
+        r = VariantRecord(
+            chrom="chr1", pos=6, ref="T", alt="C", gene_id="gene1",
+            codon_pos=3, ref_codon="GCT", alt_codon="GCC",
+            ref_aa="A", alt_aa="A", variant_class="synonymous",
+            ao=20, ro=80, dp=100, af=0.2,
+        )
+        assert r.chrom == "chr1"
+        assert r.pos == 6
+        assert r.variant_class == "synonymous"
+        assert r.strand == "+"  # default
+        assert r.cds_position == 0  # default
+        assert r.n_sites == 0.0  # default
+        assert r.s_sites == 0.0  # default
+
+
+class TestAnnotateVariants:
+    def test_synonymous_variant(self):
+        """GCT -> GCC (Ala -> Ala) at codon_pos 3 is synonymous."""
+        codons = ["ATG", "GCT", "GAT"]
+        positions = [("chr1", 0, 1, 2), ("chr1", 3, 4, 5), ("chr1", 6, 7, 8)]
+        variants = [Variant(pos=5, ref="T", alt="C", freq=0.2, depth=100, ao=20, ro=80)]
+        records = annotate_variants(codons=codons, positions=positions, variants=variants, gene_id="gene1", strand="+")
+        assert len(records) == 1
+        r = records[0]
+        assert r.chrom == "chr1"
+        assert r.pos == 6  # 1-based
+        assert r.ref_codon == "GCT"
+        assert r.alt_codon == "GCC"
+        assert r.ref_aa == "A"
+        assert r.alt_aa == "A"
+        assert r.variant_class == "synonymous"
+        assert r.codon_pos == 3
+        assert r.ao == 20
+        assert r.ro == 80
+        assert r.dp == 100
+        assert r.af == pytest.approx(20 / (20 + 80))
+
+    def test_nonsynonymous_variant(self):
+        codons = ["ATG", "GCT", "GAT"]
+        positions = [("chr1", 0, 1, 2), ("chr1", 3, 4, 5), ("chr1", 6, 7, 8)]
+        variants = [Variant(pos=6, ref="G", alt="A", freq=0.3, depth=100, ao=30, ro=70)]
+        records = annotate_variants(codons=codons, positions=positions, variants=variants, gene_id="gene1", strand="+")
+        r = records[0]
+        assert r.ref_codon == "GAT"
+        assert r.alt_codon == "AAT"
+        assert r.ref_aa == "D"
+        assert r.alt_aa == "N"
+        assert r.variant_class == "nonsynonymous"
+        assert r.codon_pos == 1
+
+    def test_minus_strand_complement(self):
+        codons = ["CAG"]
+        positions = [("chr1", 8, 7, 6)]
+        variants = [Variant(pos=7, ref="T", alt="G", freq=0.25, depth=80, ao=20, ro=60)]
+        records = annotate_variants(codons=codons, positions=positions, variants=variants, gene_id="gene3", strand="-")
+        r = records[0]
+        assert r.ref_codon == "CAG"
+        assert r.alt_codon == "CCG"
+        assert r.strand == "-"
+
+    def test_stop_gained(self):
+        codons = ["TGG"]
+        positions = [("chr1", 0, 1, 2)]
+        variants = [Variant(pos=2, ref="G", alt="A", freq=0.05, depth=100, ao=5, ro=95)]
+        records = annotate_variants(codons=codons, positions=positions, variants=variants, gene_id="gene1", strand="+")
+        assert records[0].variant_class == "stop_gained"
+        assert records[0].alt_aa == "*"
+
+    def test_variant_outside_codons_skipped(self):
+        codons = ["ATG"]
+        positions = [("chr1", 0, 1, 2)]
+        variants = [Variant(pos=99, ref="A", alt="G", freq=0.1, depth=100, ao=10, ro=90)]
+        records = annotate_variants(codons=codons, positions=positions, variants=variants, gene_id="gene1", strand="+")
+        assert len(records) == 0
+
+    def test_af_computed_from_ao_ro(self):
+        codons = ["AAA"]
+        positions = [("chr1", 0, 1, 2)]
+        variants = [Variant(pos=0, ref="A", alt="G", freq=0.5, depth=200, ao=20, ro=80)]
+        records = annotate_variants(codons=codons, positions=positions, variants=variants, gene_id="gene1", strand="+")
+        assert records[0].af == pytest.approx(0.2)
+
+    def test_cds_position(self):
+        codons = ["ATG", "GCT", "GAT"]
+        positions = [("chr1", 0, 1, 2), ("chr1", 3, 4, 5), ("chr1", 6, 7, 8)]
+        variants = [Variant(pos=7, ref="A", alt="G", freq=0.1, depth=100, ao=10, ro=90)]
+        records = annotate_variants(codons=codons, positions=positions, variants=variants, gene_id="gene1", strand="+")
+        assert records[0].cds_position == 8  # codon_idx=2, pos_in=1 -> 2*3+1+1=8
+
+    def test_n_sites_s_sites(self):
+        codons = ["GCT"]
+        positions = [("chr1", 0, 1, 2)]
+        variants = [Variant(pos=2, ref="T", alt="C", freq=0.2, depth=100, ao=20, ro=80)]
+        records = annotate_variants(codons=codons, positions=positions, variants=variants, gene_id="gene1", strand="+")
+        from pie.codon import N_SITES, S_SITES, CODON_TO_INDEX
+        idx = CODON_TO_INDEX["GCT"]
+        assert records[0].n_sites == pytest.approx(float(N_SITES[idx, 2]))
+        assert records[0].s_sites == pytest.approx(float(S_SITES[idx, 2]))
+
+
+class TestComputeGeneDiversityVariantRecords:
+    def test_variant_records_populated(self, ref_fasta, gff3_file, vcf_file):
+        from pie.reference import ReferenceGenome
+        from pie.annotation import parse_annotations
+        from pie.vcf import VariantReader
+
+        genes = parse_annotations(gff3_file)
+        gene1 = [g for g in genes if "gene1" in g.gene_id.lower()][0]
+
+        with ReferenceGenome(ref_fasta) as ref, \
+             VariantReader(vcf_file, min_freq=0.0, min_depth=0, min_qual=0) as vcf:
+            result = compute_gene_diversity(gene1, ref, vcf, emit_variants=True)
+
+        assert result.variant_records is not None
+        assert len(result.variant_records) == 2
+
+        syn = [r for r in result.variant_records if r.pos == 6][0]
+        assert syn.variant_class == "synonymous"
+        assert syn.ref_codon == "GCT"
+        assert syn.alt_codon == "GCC"
+        assert syn.ao == 20
+        assert syn.ro == 80
+
+        nsyn = [r for r in result.variant_records if r.pos == 7][0]
+        assert nsyn.variant_class == "nonsynonymous"
+        assert nsyn.ref_codon == "GAT"
+        assert nsyn.alt_codon == "AAT"
+        assert nsyn.ref_aa == "D"
+        assert nsyn.alt_aa == "N"
+        assert nsyn.ao == 30
+        assert nsyn.ro == 70
+
+    def test_variant_records_none_by_default(self, ref_fasta, gff3_file, vcf_file):
+        from pie.reference import ReferenceGenome
+        from pie.annotation import parse_annotations
+        from pie.vcf import VariantReader
+
+        genes = parse_annotations(gff3_file)
+        gene1 = [g for g in genes if "gene1" in g.gene_id.lower()][0]
+
+        with ReferenceGenome(ref_fasta) as ref, \
+             VariantReader(vcf_file, min_freq=0.0, min_depth=0, min_qual=0) as vcf:
+            result = compute_gene_diversity(gene1, ref, vcf)
+
+        assert result.variant_records is None

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -517,12 +517,28 @@ class TestAnnotateVariants:
         records = annotate_variants(codons=codons, positions=positions, variants=variants, gene_id="gene1", strand="+")
         assert len(records) == 0
 
-    def test_af_computed_from_ao_ro(self):
+    def test_af_uses_site_depth(self):
+        """AF = ao/dp (site-wide depth), not ao/(ao+ro)."""
         codons = ["AAA"]
         positions = [("chr1", 0, 1, 2)]
-        variants = [Variant(pos=0, ref="A", alt="G", freq=0.5, depth=200, ao=20, ro=80)]
+        # depth=200 but ao+ro=100 — simulates a multiallelic site
+        variants = [Variant(pos=0, ref="A", alt="G", freq=0.1, depth=200, ao=20, ro=80)]
         records = annotate_variants(codons=codons, positions=positions, variants=variants, gene_id="gene1", strand="+")
-        assert records[0].af == pytest.approx(0.2)
+        assert records[0].af == pytest.approx(20 / 200)  # 0.1, not 20/100=0.2
+
+    def test_af_multiallelic_site(self):
+        """Two ALTs at the same codon position get correct AF from site depth."""
+        codons = ["AAA"]
+        positions = [("chr1", 0, 1, 2)]
+        # Triallelic: ref=50, alt1=30, alt2=20, total=100
+        variants = [
+            Variant(pos=0, ref="A", alt="G", freq=0.3, depth=100, ao=30, ro=50),
+            Variant(pos=0, ref="A", alt="C", freq=0.2, depth=100, ao=20, ro=50),
+        ]
+        records = annotate_variants(codons=codons, positions=positions, variants=variants, gene_id="gene1", strand="+")
+        assert len(records) == 2
+        assert records[0].af == pytest.approx(0.30)  # 30/100, not 30/80
+        assert records[1].af == pytest.approx(0.20)  # 20/100, not 20/70
 
     def test_cds_position(self):
         codons = ["ATG", "GCT", "GAT"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,6 +10,8 @@ Test data layout (chr1, 350 bp):
   Gene3: pos 231-311, - strand, 27 codons (26 excl. stop), 1 low-QUAL variant
 """
 
+import os
+
 import pandas as pd
 from pie.cli import main
 
@@ -281,3 +283,37 @@ class TestIndividualMode:
         assert (out / "gene_results.tsv").exists()
         assert (out / "window_results.tsv").exists()
         assert (out / "summary.tsv").exists()
+
+
+class TestVariantTableIntegration:
+    def test_variant_table_content_matches_gene_results(
+        self, runner, ref_fasta, gff3_file, vcf_file, tmp_path
+    ):
+        """Variant table variant count per gene <= n_variants in gene_results."""
+        from pie.cli import main
+        outdir = str(tmp_path / "out")
+        result = runner.invoke(main, [
+            "pool", "-v", vcf_file, "-g", gff3_file, "-f", ref_fasta,
+            "-o", outdir, "-d", "0", "-q", "0", "--min-freq", "0",
+            "--variant-table",
+        ])
+        assert result.exit_code == 0
+
+        genes = pd.read_csv(os.path.join(outdir, "gene_results.tsv"), sep="\t")
+        variants = pd.read_csv(os.path.join(outdir, "variant_results.tsv"), sep="\t")
+
+        for _, grow in genes.iterrows():
+            gid = grow["gene_id"]
+            gene_vars = variants[variants["gene_id"] == gid]
+            assert len(gene_vars) <= grow["n_variants"], (
+                f"Gene {gid}: variant_results has {len(gene_vars)} rows "
+                f"but gene_results says n_variants={grow['n_variants']}"
+            )
+
+        # Total variant rows should be > 0 for test data
+        assert len(variants) > 0
+
+        # AF must be computed from ao/ro, not VCF AF
+        for _, row in variants.iterrows():
+            expected_af = row["ao"] / (row["ao"] + row["ro"])
+            assert abs(row["af"] - expected_af) < 1e-6

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -313,7 +313,7 @@ class TestVariantTableIntegration:
         # Total variant rows should be > 0 for test data
         assert len(variants) > 0
 
-        # AF must be computed from ao/ro, not VCF AF
+        # AF must be computed from read counts (ao/dp), not VCF AF
         for _, row in variants.iterrows():
-            expected_af = row["ao"] / (row["ao"] + row["ro"])
+            expected_af = row["ao"] / row["dp"]
             assert abs(row["af"] - expected_af) < 1e-6

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,7 +1,7 @@
 import pytest
 import pandas as pd
-from pie.io import write_gene_results, write_window_results, write_summary
-from pie.diversity import GeneResult, CodonResult
+from pie.io import write_gene_results, write_window_results, write_summary, write_variant_results
+from pie.diversity import GeneResult, CodonResult, VariantRecord
 
 
 class TestIndividualModeColumns:
@@ -163,3 +163,54 @@ class TestWriteSummary:
         df = pd.read_csv(outpath, sep="\t")
         assert df.iloc[0]["stop_renorm_genes"] == 2   # g1 and g3
         assert df.iloc[0]["stop_renorm_codons"] == 4   # 3 + 0 + 1
+
+
+class TestWriteVariantResults:
+    def _make_records(self):
+        return [
+            VariantRecord(
+                chrom="chr1", pos=6, ref="T", alt="C", gene_id="gene1",
+                codon_pos=3, ref_codon="GCT", alt_codon="GCC",
+                ref_aa="A", alt_aa="A", variant_class="synonymous",
+                ao=20, ro=80, dp=100, af=0.2,
+                strand="+", cds_position=6, n_sites=0.0, s_sites=1.0,
+            ),
+            VariantRecord(
+                chrom="chr1", pos=7, ref="G", alt="A", gene_id="gene1",
+                codon_pos=1, ref_codon="GAT", alt_codon="AAT",
+                ref_aa="D", alt_aa="N", variant_class="nonsynonymous",
+                ao=30, ro=70, dp=100, af=0.3,
+                strand="+", cds_position=7, n_sites=1.0, s_sites=0.0,
+            ),
+        ]
+
+    def test_writes_tsv(self, tmp_path):
+        path = str(tmp_path / "variant_results.tsv")
+        write_variant_results(self._make_records(), path)
+        df = pd.read_csv(path, sep="\t")
+        assert len(df) == 2
+        assert set(df.columns) >= {
+            "chrom", "pos", "ref", "alt", "gene_id", "variant_class",
+            "ao", "ro", "dp", "af",
+        }
+
+    def test_correct_values(self, tmp_path):
+        path = str(tmp_path / "variant_results.tsv")
+        write_variant_results(self._make_records(), path)
+        df = pd.read_csv(path, sep="\t")
+        row = df.iloc[0]
+        assert row["chrom"] == "chr1"
+        assert row["pos"] == 6
+        assert row["ref"] == "T"
+        assert row["alt"] == "C"
+        assert row["variant_class"] == "synonymous"
+        assert row["ao"] == 20
+        assert row["ro"] == 80
+        assert abs(row["af"] - 0.2) < 1e-6
+
+    def test_empty_records(self, tmp_path):
+        path = str(tmp_path / "variant_results.tsv")
+        write_variant_results([], path)
+        df = pd.read_csv(path, sep="\t")
+        assert len(df) == 0
+        assert "chrom" in df.columns

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -97,6 +97,42 @@ class TestVariantReader:
             assert variants[0].pos == 296
 
 
+class TestVariantAoRo:
+    """Tests for ao/ro fields on Variant objects."""
+
+    def test_pool_variant_has_ao_ro(self, vcf_file):
+        """Pool-mode variants from AD field populate ao and ro."""
+        with VariantReader(vcf_file, min_freq=0.0, min_depth=0, min_qual=0) as reader:
+            result = reader.fetch("chr1", 0, 10)
+        # pos 6 (1-based) = pos 5 (0-based): T>C, AD=80,20
+        var = [v for v in result.variants if v.pos == 5][0]
+        assert var.ao == 20
+        assert var.ro == 80
+
+    def test_pool_variant_ao_ro_second_variant(self, vcf_file):
+        """Second variant also has correct ao/ro."""
+        with VariantReader(vcf_file, min_freq=0.0, min_depth=0, min_qual=0) as reader:
+            result = reader.fetch("chr1", 0, 10)
+        # pos 7 (1-based) = pos 6 (0-based): G>A, AD=70,30
+        var = [v for v in result.variants if v.pos == 6][0]
+        assert var.ao == 30
+        assert var.ro == 70
+
+    def test_individual_variant_has_ao_ro(self, individual_vcf_file):
+        """Individual-mode variants populate ao/ro from GT allele counts."""
+        with IndividualVariantReader(
+            individual_vcf_file, samples=["S1", "S2", "S3", "S4"],
+            min_freq=0.0, min_qual=0.0, pass_only=False,
+            keep_multiallelic=False, min_call_rate=0.0, min_an=0,
+        ) as reader:
+            result = reader.fetch("chr1", 0, 10)
+        # pos 6 (1-based) = pos 5: T>C, S1:0/1 S2:0/0 S3:0/1 S4:./.
+        # called=3, ref_count=4, alt_count=2
+        var = [v for v in result.variants if v.pos == 5][0]
+        assert var.ao == 2
+        assert var.ro == 4
+
+
 class TestMultiallelicFiltering:
     def test_default_skips_multiallelic(self, multiallelic_vcf_file):
         """Default behavior: positions with >1 ALT allele are discarded."""


### PR DESCRIPTION
## Summary

- Add `--variant-table` opt-in flag to `pie pool` and `pie ind` that writes a per-variant TSV (`variant_results.tsv`) with codon/AA annotation, read counts, and allele frequencies
- Output columns: chrom, pos, ref, alt, gene_id, codon_pos, ref_codon, alt_codon, ref_aa, alt_aa, variant_class, ao, ro, dp, af, strand, cds_position, n_sites, s_sites
- AF is computed from read counts (`ao/dp`), not from VCF INFO/AF field
- Zero overhead when flag is not used (default off)

### Changes by file
| File | Change |
|------|--------|
| `vcf.py` | Add `ao`/`ro` fields to `Variant` dataclass, store in both readers |
| `diversity.py` | `VariantRecord` dataclass, `annotate_variants()`, `_build_pos_map()` helper, `emit_variants` param on `compute_gene_diversity()` |
| `io.py` | `write_variant_results()` using `dataclasses.fields()` for auto-tracking columns |
| `parallel.py` | Thread `emit_variants` through worker init/process |
| `cli.py` | `--variant-table` shared option, write output in `_run_analysis()` |

## Test plan

- [x] `pytest tests/test_vcf.py::TestVariantAoRo` — ao/ro populated in pool and individual mode
- [x] `pytest tests/test_diversity.py::TestAnnotateVariants` — synonymous, nonsynonymous, stop_gained, minus strand, multiallelic AF, CDS position, N/S sites
- [x] `pytest tests/test_io.py::TestWriteVariantResults` — TSV structure, values, empty records
- [x] `pytest tests/test_cli.py::TestVariantTableFlag` — flag produces file, absent by default
- [x] `pytest tests/test_integration.py::TestVariantTableIntegration` — variant count consistency with gene_results, AF = ao/dp
- [x] Full suite: 257 tests pass